### PR TITLE
Experiment on converting from one format to the other

### DIFF
--- a/noodles-bed/Cargo.toml
+++ b/noodles-bed/Cargo.toml
@@ -14,4 +14,5 @@ documentation = "https://docs.rs/noodles-bed"
 noodles-core = { path = "../noodles-core", version = "0.7.0" }
 serde = { version = "1" }
 serde_json = "1.0"
+serde-transcode = "1.1.1"
 serde_with = "2.0.0"

--- a/noodles-bed/src/de.rs
+++ b/noodles-bed/src/de.rs
@@ -4,6 +4,98 @@ use error::{Error, Result};
 use serde::de::{DeserializeSeed, SeqAccess, Visitor};
 use serde::{de, forward_to_deserialize_any, ser, Deserialize};
 
+// /// This leeps track of the state associated with the next record that is parsed.
+// /// We need to keep track of the state as records are returned whole from the iterator, whereas
+// /// the deserializer progresses one field at a time.
+// enum RecordState {
+//     ExpectingChrom,
+//     ExpectingChromStart(Record<3>),
+//     ExpectingChromEnd(Record<3>),
+// }
+
+// /// The Record Deserializer. This struct implements Deserializer and associated Traits. It stores
+// /// an iterator over the records that are given to it.
+// pub struct Record3Deserializer<I>
+// where
+//     I: Iterator<Item = io::Result<Record<3>>>,
+// {
+//     records: Peekable<I>,
+//     state: RecordState,
+// }
+
+// impl<I> Record3Deserializer<I>
+// where
+//     I: Iterator<Item = io::Result<Record<3>>>,
+// {
+//     fn new(records: I) -> Self {
+//         Self {
+//             records: records.peekable(),
+//             state: ExpectingChrom,
+//         }
+//     }
+// }
+
+// impl<'de, 'a, I> Deserializer<'de> for &'a mut Record3Deserializer<I>
+// where
+//     I: Iterator<Item = io::Result<Record<3>>>,
+// {
+//     type Error = Error;
+
+//     /// This function could handle deserializing an individual record, matching the deserializer's
+//     /// RecordState, and progressing it to the next state.
+//     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
+//     where
+//         V: Visitor<'de>,
+//     {
+//         todo!()
+//     }
+
+//     /// We will likely need to handle deserializing a sequence.
+//     fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value>
+//     where
+//         V: Visitor<'de>,
+//     {
+//         visitor.visit_seq(self)
+//     }
+
+//     /// We also need to deserialize a struct in a similar way, as the BED
+//     /// format doesn't have a concept of a struct. It just processes records
+//     /// line by line similar to CSV, where fields are separated by some separator.
+//     fn deserialize_struct<V>(
+//         self,
+//         name: &'static str,
+//         fields: &'static [&'static str],
+//         visitor: V,
+//     ) -> Result<V::Value>
+//     where
+//         V: Visitor<'de>,
+//     {
+//         visitor.visit_seq(self)
+//     }
+
+//     /// We can probably use forward_to_deserialize_any for many types, as bed Records are self-describing.
+//     forward_to_deserialize_any! {
+//           bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+//           bytes byte_buf option unit unit_struct newtype_struct tuple
+//           tuple_struct map enum identifier ignored_any
+//     }
+// }
+
+// /// SeqAccess will be needed to deserialize sequences and structs.
+// impl<'de, I> SeqAccess<'de> for Record3Deserializer<I>
+// where
+//     I: Iterator<Item = io::Result<Record<3>>>,
+// {
+//     type Error = Error;
+
+//     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
+//     where
+//         T: DeserializeSeed<'de>,
+//     {
+//         todo!()
+//     }
+// }
+
 pub struct RecordDeserializer<'de> {
     input: &'de str,
 }
@@ -185,7 +277,7 @@ mod serde_tests {
     }
 
     #[test]
-    fn test_to_string_single_auxiliar_bed_record_5_wrapper() {
+    fn test_from_str_single_auxiliar_bed_record_5_wrapper() {
         let input = "sq0\t7\t13\t.\t21";
         let result: Record<5> = record_from_str(input).unwrap();
 
@@ -201,7 +293,7 @@ mod serde_tests {
     }
 
     #[test]
-    fn test_to_string_single_auxiliar_bed_record_6_wrapper() {
+    fn test_from_str_single_auxiliar_bed_record_6_wrapper() {
         let input = "sq0\t7\t13\t.\t0\t+";
         let result: Record<6> = record_from_str(input).unwrap();
 
@@ -217,7 +309,7 @@ mod serde_tests {
     }
 
     #[test]
-    fn test_to_string_single_auxiliar_bed_record_7_wrapper() {
+    fn test_from_str_single_auxiliar_bed_record_7_wrapper() {
         let input = "sq0\t7\t13\t.\t0\t.\t7";
         let result: Record<7> = record_from_str(input).unwrap();
 
@@ -235,7 +327,7 @@ mod serde_tests {
     }
 
     #[test]
-    fn test_to_string_single_auxiliar_bed_record_8_wrapper() {
+    fn test_from_str_single_auxiliar_bed_record_8_wrapper() {
         let input = "sq0\t7\t13\t.\t0\t.\t7\t13";
         let result: Record<8> = record_from_str(input).unwrap();
 
@@ -255,7 +347,7 @@ mod serde_tests {
     }
 
     #[test]
-    fn test_to_string_single_auxiliar_bed_record_9_wrapper() {
+    fn test_from_str_single_auxiliar_bed_record_9_wrapper() {
         let input = "sq0\t7\t13\t.\t0\t.\t7\t13\t255,0,0";
         let result: Record<9> = record_from_str(input).unwrap();
 
@@ -276,7 +368,7 @@ mod serde_tests {
     }
 
     #[test]
-    fn test_to_string_single_auxiliar_bed_record_12_wrapper() {
+    fn test_from_str_single_auxiliar_bed_record_12_wrapper() {
         let input = "sq0\t7\t13\t.\t0\t.\t7\t13\t0\t1\t2\t0";
         let result: Record<12> = record_from_str(input).unwrap();
 

--- a/noodles-bed/src/lib.rs
+++ b/noodles-bed/src/lib.rs
@@ -15,4 +15,5 @@ mod ser;
 
 pub use de::{from_bytes, record_from_str, vec_record_from_str, RecordDeserializer};
 pub use error::{Error, Result};
-pub use ser::{record_to_string, to_bytes, vec_record_to_string, RecordSerializer};
+// pub use ser::{record_to_string, to_bytes, vec_record_to_string, RecordSerializer};
+pub use ser::{to_bytes, RecordSerializer};

--- a/noodles-bed/src/main.rs
+++ b/noodles-bed/src/main.rs
@@ -1,5 +1,5 @@
 use crate::bioserde::{
-    convert_to_format, json_bed_to_noodles_bed, noodles_bed_to_json_bed, SupportedFormat,
+    convert_to_format, json_bed3_to_noodles_bed3, noodles_bed3_to_json_bed3, SupportedFormat,
 };
 use noodles_bed::Record;
 use noodles_core::Position;
@@ -15,6 +15,32 @@ mod bioserde {
     }
 
     pub fn convert_to_format(input: &str, from: SupportedFormat, to: SupportedFormat) -> String {
+        use SupportedFormat::*;
+
+        match (from, to) {
+            // we can later use:
+            //   _ => panic!()
+            // just making it explicit for now.
+            (Record3, Record3) => input.to_string(),
+            (Record3, Record4) => panic!(),
+            (Record3, JsonBed3) => noodles_bed3_to_json_bed3(input),
+            (Record3, JsonBed4) => panic!(),
+            (Record4, Record3) => panic!(),
+            (Record4, Record4) => input.to_string(),
+            (Record4, JsonBed3) => panic!(),
+            (Record4, JsonBed4) => noodles_bed4_to_json_bed4(input),
+            (JsonBed3, Record3) => json_bed3_to_noodles_bed3(input),
+            (JsonBed3, Record4) => panic!(),
+            (JsonBed3, JsonBed3) => input.to_string(),
+            (JsonBed3, JsonBed4) => panic!(),
+            (JsonBed4, Record3) => panic!(),
+            (JsonBed4, Record4) => json_bed4_to_noodles_bed4(input),
+            (JsonBed4, JsonBed3) => panic!(),
+            (JsonBed4, JsonBed4) => input.to_string(),
+        }
+    }
+
+    pub fn bla(input: &str, from: SupportedFormat, to: SupportedFormat) -> String {
         let record = match from {
             SupportedFormat::Record3 => noodles_bed::record_from_str::<Record<3>>(input).unwrap(),
             SupportedFormat::Record4 => noodles_bed::record_from_str::<Record<4>>(input).unwrap(),
@@ -35,7 +61,7 @@ mod bioserde {
     /// A function that receives a string in the noodles-bedrepresentation,
     /// deserialize to a Record<3>, and reserialize to a json-bed representation
     /// TODO: deserialize to a Record<N>
-    pub fn noodles_bed_to_json_bed(input: &str) -> String {
+    pub fn noodles_bed3_to_json_bed3(input: &str) -> String {
         let record: Record<3> = noodles_bed::record_from_str(input).unwrap();
 
         // TODO: start treating errors
@@ -45,10 +71,21 @@ mod bioserde {
     /// A function that receives a string in the json-bed representation,
     /// deserialize to a Record<3>, and reserialize to a noodles-bed representation
     /// TODO: deserialize to a Record<N>
-    pub fn json_bed_to_noodles_bed(input: &str) -> String {
+    pub fn json_bed3_to_noodles_bed3(input: &str) -> String {
         let record: Record<3> = serde_json::from_str(input).unwrap();
 
         // TODO: start treating errors
+        noodles_bed::record_to_string(record).unwrap()
+    }
+
+    // test
+    pub fn noodles_bed4_to_json_bed4(input: &str) -> String {
+        let record: Record<4> = noodles_bed::record_from_str(input).unwrap();
+        serde_json::to_string(&record).unwrap()
+    }
+
+    pub fn json_bed4_to_noodles_bed4(input: &str) -> String {
+        let record: Record<4> = serde_json::from_str(input).unwrap();
         noodles_bed::record_to_string(record).unwrap()
     }
 
@@ -57,25 +94,25 @@ mod bioserde {
         use super::*;
 
         #[test]
-        fn test_json_bed_to_noodles_bed() {
+        fn test_json_bed3_to_noodles_bed3() {
             let input = r#"{"chrom":"sq0","start":8,"end":13}"#;
-            let result = json_bed_to_noodles_bed(input);
+            let result = json_bed3_to_noodles_bed3(input);
 
             let expected = "sq0\t7\t13";
             assert_eq!(&result, expected);
         }
 
         #[test]
-        fn test_noodles_bed_to_json_bed() {
+        fn test_noodles_bed3_to_json_bed3() {
             let input = "sq0\t7\t13";
-            let result = noodles_bed_to_json_bed(input);
+            let result = noodles_bed3_to_json_bed3(input);
 
             let expected = r#"{"chrom":"sq0","start":8,"end":13,"name":null,"score":null,"strand":null,"thick_start":8,"thick_end":13,"color":null,"blocks":[]}"#;
             assert_eq!(&result, expected);
         }
 
         #[test]
-        fn test_json_bed_to_noodles_bed_with_enum_usage() {
+        fn test_json_bed3_to_noodles_bed3_with_enum_usage() {
             let input = r#"{"chrom":"sq0","start":8,"end":13}"#;
             let result =
                 convert_to_format(input, SupportedFormat::JsonBed3, SupportedFormat::Record3);
@@ -85,12 +122,32 @@ mod bioserde {
         }
 
         #[test]
-        fn test_noodles_bed_to_json_bed_with_enum_usage() {
+        fn test_noodles_bed3_to_json_bed3_with_enum_usage() {
             let input = "sq0\t7\t13";
             let result =
                 convert_to_format(input, SupportedFormat::Record3, SupportedFormat::JsonBed3);
 
             let expected = r#"{"chrom":"sq0","start":8,"end":13,"name":null,"score":null,"strand":null,"thick_start":8,"thick_end":13,"color":null,"blocks":[]}"#;
+            assert_eq!(&result, expected);
+        }
+
+        #[test]
+        fn test_json_bed4_to_noodles_bed4_with_enum_usage() {
+            let input = r#"{"chrom":"sq0","start":8,"end":13,"name":"ndls1"}"#;
+            let result =
+                convert_to_format(input, SupportedFormat::JsonBed4, SupportedFormat::Record4);
+
+            let expected = "sq0\t7\t13\tndls1";
+            assert_eq!(&result, expected);
+        }
+
+        #[test]
+        fn test_noodles_bed4_to_json_bed4_with_enum_usage() {
+            let input = "sq0\t7\t13\tndls1";
+            let result =
+                convert_to_format(input, SupportedFormat::Record4, SupportedFormat::JsonBed4);
+
+            let expected = r#"{"chrom":"sq0","start":8,"end":13,"name":"ndls1","score":null,"strand":null,"thick_start":8,"thick_end":13,"color":null,"blocks":[]}"#;
             assert_eq!(&result, expected);
         }
     }
@@ -154,17 +211,17 @@ fn main() {
 
     // From noodles-bed representation to json-bed representation
     let input = r#"{"chrom":"sq0","start":8,"end":13}"#;
-    let result = json_bed_to_noodles_bed(input);
+    let result = json_bed3_to_noodles_bed3(input);
     println!(
-        "json_bed_to_noodles_bed: input: {:?}, result: {:?}",
+        "json_bed3_to_noodles_bed3: input: {:?}, result: {:?}",
         input, result
     );
 
     // From json-bed representation to noodles-bed representation
     let input = "sq0\t7\t13";
-    let result = noodles_bed_to_json_bed(input);
+    let result = noodles_bed3_to_json_bed3(input);
     println!(
-        "noodles_bed_to_json_bed: input: {:?}, result: {:?}",
+        "noodles_bed3_to_json_bed3: input: {:?}, result: {:?}",
         input, result
     );
 

--- a/noodles-bed/src/main.rs
+++ b/noodles-bed/src/main.rs
@@ -35,7 +35,8 @@ fn main() {
         .build()
         .unwrap();
 
-    println!("{:#?}", noodles_bed::record_to_string(record).unwrap());
+    // TODO: remove and/or fix
+    // println!("{:#?}", noodles_bed::record_to_string(record).unwrap());
 
     // Failing serde-transcode example:
     // From json representation to noodles-bed representation
@@ -53,3 +54,62 @@ fn main() {
 
     // From noodles-bed representation to json representation
 }
+
+// #[cfg(test)]
+// mod bioserde_tests {
+//     use super::*;
+
+//     #[test]
+//     fn test_json_bed3_to_noodles_bed3() {
+//         let input = r#"{"chrom":"sq0","start":8,"end":13}"#;
+//         let result = json_bed3_to_noodles_bed3(input);
+
+//         let expected = "sq0\t7\t13";
+//         assert_eq!(&result, expected);
+//     }
+
+//     #[test]
+//     fn test_noodles_bed3_to_json_bed3() {
+//         let input = "sq0\t7\t13";
+//         let result = noodles_bed3_to_json_bed3(input);
+
+//         let expected = r#"{"chrom":"sq0","start":8,"end":13,"name":null,"score":null,"strand":null,"thick_start":8,"thick_end":13,"color":null,"blocks":[]}"#;
+//         assert_eq!(&result, expected);
+//     }
+
+//     #[test]
+//     fn test_json_bed3_to_noodles_bed3_with_enum_usage() {
+//         let input = r#"{"chrom":"sq0","start":8,"end":13}"#;
+//         let result = convert_to_format(input, SupportedFormat::JsonBed3, SupportedFormat::Record3);
+
+//         let expected = "sq0\t7\t13";
+//         assert_eq!(&result, expected);
+//     }
+
+//     #[test]
+//     fn test_noodles_bed3_to_json_bed3_with_enum_usage() {
+//         let input = "sq0\t7\t13";
+//         let result = convert_to_format(input, SupportedFormat::Record3, SupportedFormat::JsonBed3);
+
+//         let expected = r#"{"chrom":"sq0","start":8,"end":13,"name":null,"score":null,"strand":null,"thick_start":8,"thick_end":13,"color":null,"blocks":[]}"#;
+//         assert_eq!(&result, expected);
+//     }
+
+//     #[test]
+//     fn test_json_bed4_to_noodles_bed4_with_enum_usage() {
+//         let input = r#"{"chrom":"sq0","start":8,"end":13,"name":"ndls1"}"#;
+//         let result = convert_to_format(input, SupportedFormat::JsonBed4, SupportedFormat::Record4);
+
+//         let expected = "sq0\t7\t13\tndls1";
+//         assert_eq!(&result, expected);
+//     }
+
+//     #[test]
+//     fn test_noodles_bed4_to_json_bed4_with_enum_usage() {
+//         let input = "sq0\t7\t13\tndls1";
+//         let result = convert_to_format(input, SupportedFormat::Record4, SupportedFormat::JsonBed4);
+
+//         let expected = r#"{"chrom":"sq0","start":8,"end":13,"name":"ndls1","score":null,"strand":null,"thick_start":8,"thick_end":13,"color":null,"blocks":[]}"#;
+//         assert_eq!(&result, expected);
+//     }
+// }

--- a/noodles-bed/src/main.rs
+++ b/noodles-bed/src/main.rs
@@ -9,24 +9,26 @@ mod bioserde {
 
     pub enum SupportedFormat {
         Record3,
+        Record4,
         JsonBed3,
+        JsonBed4,
     }
 
     pub fn convert_to_format(input: &str, from: SupportedFormat, to: SupportedFormat) -> String {
         let record = match from {
-            SupportedFormat::Record3 => {
-                let record: Record<3> = noodles_bed::record_from_str(input).unwrap();
-                record
-            }
-            SupportedFormat::JsonBed3 => {
-                let record: Record<3> = serde_json::from_str(input).unwrap();
-                record
-            }
+            SupportedFormat::Record3 => noodles_bed::record_from_str::<Record<3>>(input).unwrap(),
+            SupportedFormat::Record4 => noodles_bed::record_from_str::<Record<4>>(input).unwrap(),
+            SupportedFormat::JsonBed3 => serde_json::from_str::<Record<3>>(input).unwrap(),
+            SupportedFormat::JsonBed4 => serde_json::from_str::<Record<4>>(input).unwrap(),
         };
 
         match to {
-            SupportedFormat::Record3 => noodles_bed::record_to_string(record).unwrap(),
-            SupportedFormat::JsonBed3 => serde_json::to_string(&record).unwrap(),
+            SupportedFormat::Record3 | SupportedFormat::Record4 => {
+                noodles_bed::record_to_string(record).unwrap()
+            }
+            SupportedFormat::JsonBed3 | SupportedFormat::JsonBed4 => {
+                serde_json::to_string(&record).unwrap()
+            }
         }
     }
 

--- a/noodles-bed/src/main.rs
+++ b/noodles-bed/src/main.rs
@@ -1,5 +1,56 @@
+use crate::bioserde::{json_bed_to_noodles_bed, noodles_bed_to_json_bed};
 use noodles_bed::Record;
 use noodles_core::Position;
+
+mod bioserde {
+    use noodles_bed::Record;
+
+    // TODO: check if this signature still makes sense
+    // pub fn convert_serde_format(format_one, format_two)
+
+    /// A function that receives a string in the noodles-bedrepresentation,
+    /// deserialize to a Record<3>, and reserialize to a json-bed representation
+    /// TODO: deserialize to a Record<N>
+    pub fn noodles_bed_to_json_bed(input: &str) -> String {
+        let record: Record<3> = noodles_bed::record_from_str(input).unwrap();
+
+        // TODO: start treating errors
+        serde_json::to_string(&record).unwrap()
+    }
+
+    /// A function that receives a string in the json-bed representation,
+    /// deserialize to a Record<3>, and reserialize to a noodles-bed representation
+    /// TODO: deserialize to a Record<N>
+    pub fn json_bed_to_noodles_bed(input: &str) -> String {
+        let record: Record<3> = serde_json::from_str(input).unwrap();
+
+        // TODO: start treating errors
+        noodles_bed::record_to_string(record).unwrap()
+    }
+
+    #[cfg(test)]
+    mod serde_tests {
+        use super::*;
+
+        #[test]
+        fn test_json_bed_to_noodles_bed() {
+            let input = r#"{"chrom":"sq0","start":8,"end":13}"#;
+            let result = json_bed_to_noodles_bed(input);
+
+            let expected = "sq0\t7\t13";
+            assert_eq!(&result, expected);
+        }
+
+        #[test]
+        fn test_noodles_bed_to_json_bed() {
+            let input = "sq0\t7\t13";
+            let result = noodles_bed_to_json_bed(input);
+
+            let expected = r#"{"chrom":"sq0","start":8,"end":13,"name":null,"score":null,"strand":null,"thick_start":8,"thick_end":13,"color":null,"blocks":[]}"#;
+            assert_eq!(&result, expected);
+        }
+    }
+}
 
 /// Demonstration of deserialization.
 fn main() {
@@ -13,10 +64,18 @@ fn main() {
     let records: Vec<Record<3>> = serde_json::from_str(inputs).unwrap();
     println!("\n Testing Vec of json: \n{:#?}", records);
 
-    // // For the BED file format representation of a bed::Record, we need to implement our own Deserializer.
-    // let record = "sq0\t7\t13\nsq0\t20\t34\n";
+    // For the BED file format representation of a bed::Record, we need to implement our own Deserializer.
+    let record = "sq0\t7\t13";
     // let record: Record<3> = noodles_bed::record_from_str(record).unwrap();
-    // println!("{:#?}", record);
+    let record: Record<3> = noodles_bed::record_from_str(record).unwrap();
+    println!("{:#?}", record);
+
+    // TODO: check this.
+
+    // For the BED file format representation of a bed::Record, we need to implement our own Deserializer.
+    let record = "sq0\t7\t13\nsq0\t20\t34\n";
+    let vec_record: Vec<Record<3>> = noodles_bed::vec_record_from_str(record).unwrap();
+    println!("{:#?}", vec_record);
 
     // Serialization is similar, if we want the JSON representation, we can use the serde_json Serializer.
     let record = Record::<3>::builder()
@@ -37,12 +96,12 @@ fn main() {
 
     println!("{:#?}", noodles_bed::record_to_string(record).unwrap());
 
-    // Failing serde-transcode example:
-    // From json representation to noodles-bed representation
-    let input = r#"{"chrom":"sq0","start":8,"end":13}"#;
-    let mut deserializer = serde_json::Deserializer::from_str(input);
-    let mut serializer = noodles_bed::RecordSerializer::new();
-    serde_transcode::transcode(&mut deserializer, &mut serializer).unwrap();
+    // // Failing serde-transcode example:
+    // // From json representation to noodles-bed representation
+    // let input = r#"{"chrom":"sq0","start":8,"end":13}"#;
+    // let mut deserializer = serde_json::Deserializer::from_str(input);
+    // let mut serializer = noodles_bed::RecordSerializer::new();
+    // serde_transcode::transcode(&mut deserializer, &mut serializer).unwrap();
 
     // // Failing serde-transcode example:
     // // From json representation to noodles-bed representation
@@ -51,5 +110,19 @@ fn main() {
     // let mut serializer = serde_json::Serializer::new(std::io::stdout());
     // serde_transcode::transcode(&mut deserializer, &mut serializer).unwrap();
 
-    // From noodles-bed representation to json representation
+    // From noodles-bed representation to json-bed representation
+    let input = r#"{"chrom":"sq0","start":8,"end":13}"#;
+    let result = json_bed_to_noodles_bed(input);
+    println!(
+        "json_bed_to_noodles_bed: input: {:?}, result: {:?}",
+        input, result
+    );
+
+    // From json-bed representation to noodles-bed representation
+    let input = "sq0\t7\t13";
+    let result = noodles_bed_to_json_bed(input);
+    println!(
+        "noodles_bed_to_json_bed: input: {:?}, result: {:?}",
+        input, result
+    );
 }

--- a/noodles-bed/src/main.rs
+++ b/noodles-bed/src/main.rs
@@ -13,10 +13,10 @@ fn main() {
     let records: Vec<Record<3>> = serde_json::from_str(inputs).unwrap();
     println!("\n Testing Vec of json: \n{:#?}", records);
 
-    // For the BED file format representation of a bed::Record, we need to implement our own Deserializer.
-    let record = "sq0\t7\t13\nsq0\t20\t34\n";
-    let record: Record<3> = noodles_bed::record_from_str(record).unwrap();
-    println!("{:#?}", record);
+    // // For the BED file format representation of a bed::Record, we need to implement our own Deserializer.
+    // let record = "sq0\t7\t13\nsq0\t20\t34\n";
+    // let record: Record<3> = noodles_bed::record_from_str(record).unwrap();
+    // println!("{:#?}", record);
 
     // Serialization is similar, if we want the JSON representation, we can use the serde_json Serializer.
     let record = Record::<3>::builder()
@@ -36,4 +36,20 @@ fn main() {
         .unwrap();
 
     println!("{:#?}", noodles_bed::record_to_string(record).unwrap());
+
+    // Failing serde-transcode example:
+    // From json representation to noodles-bed representation
+    let input = r#"{"chrom":"sq0","start":8,"end":13}"#;
+    let mut deserializer = serde_json::Deserializer::from_str(input);
+    let mut serializer = noodles_bed::RecordSerializer::new();
+    serde_transcode::transcode(&mut deserializer, &mut serializer).unwrap();
+
+    // // Failing serde-transcode example:
+    // // From json representation to noodles-bed representation
+    // let input = r#"sq0\t7\t13\n"#;
+    // let mut deserializer = noodles_bed::RecordDeserializer::from(input);
+    // let mut serializer = serde_json::Serializer::new(std::io::stdout());
+    // serde_transcode::transcode(&mut deserializer, &mut serializer).unwrap();
+
+    // From noodles-bed representation to json representation
 }

--- a/noodles-bed/src/main.rs
+++ b/noodles-bed/src/main.rs
@@ -1,157 +1,5 @@
-use crate::bioserde::{
-    convert_to_format, json_bed3_to_noodles_bed3, noodles_bed3_to_json_bed3, SupportedFormat,
-};
 use noodles_bed::Record;
 use noodles_core::Position;
-
-mod bioserde {
-    use noodles_bed::Record;
-
-    pub enum SupportedFormat {
-        Record3,
-        Record4,
-        JsonBed3,
-        JsonBed4,
-    }
-
-    pub fn convert_to_format(input: &str, from: SupportedFormat, to: SupportedFormat) -> String {
-        use SupportedFormat::*;
-
-        match (from, to) {
-            // we can later use:
-            //   _ => panic!()
-            // just making it explicit for now.
-            (Record3, Record3) => input.to_string(),
-            (Record3, Record4) => panic!(),
-            (Record3, JsonBed3) => noodles_bed3_to_json_bed3(input),
-            (Record3, JsonBed4) => panic!(),
-            (Record4, Record3) => panic!(),
-            (Record4, Record4) => input.to_string(),
-            (Record4, JsonBed3) => panic!(),
-            (Record4, JsonBed4) => noodles_bed4_to_json_bed4(input),
-            (JsonBed3, Record3) => json_bed3_to_noodles_bed3(input),
-            (JsonBed3, Record4) => panic!(),
-            (JsonBed3, JsonBed3) => input.to_string(),
-            (JsonBed3, JsonBed4) => panic!(),
-            (JsonBed4, Record3) => panic!(),
-            (JsonBed4, Record4) => json_bed4_to_noodles_bed4(input),
-            (JsonBed4, JsonBed3) => panic!(),
-            (JsonBed4, JsonBed4) => input.to_string(),
-        }
-    }
-
-    pub fn bla(input: &str, from: SupportedFormat, to: SupportedFormat) -> String {
-        let record = match from {
-            SupportedFormat::Record3 => noodles_bed::record_from_str::<Record<3>>(input).unwrap(),
-            SupportedFormat::Record4 => noodles_bed::record_from_str::<Record<4>>(input).unwrap(),
-            SupportedFormat::JsonBed3 => serde_json::from_str::<Record<3>>(input).unwrap(),
-            SupportedFormat::JsonBed4 => serde_json::from_str::<Record<4>>(input).unwrap(),
-        };
-
-        match to {
-            SupportedFormat::Record3 | SupportedFormat::Record4 => {
-                noodles_bed::record_to_string(record).unwrap()
-            }
-            SupportedFormat::JsonBed3 | SupportedFormat::JsonBed4 => {
-                serde_json::to_string(&record).unwrap()
-            }
-        }
-    }
-
-    /// A function that receives a string in the noodles-bedrepresentation,
-    /// deserialize to a Record<3>, and reserialize to a json-bed representation
-    /// TODO: deserialize to a Record<N>
-    pub fn noodles_bed3_to_json_bed3(input: &str) -> String {
-        let record: Record<3> = noodles_bed::record_from_str(input).unwrap();
-
-        // TODO: start treating errors
-        serde_json::to_string(&record).unwrap()
-    }
-
-    /// A function that receives a string in the json-bed representation,
-    /// deserialize to a Record<3>, and reserialize to a noodles-bed representation
-    /// TODO: deserialize to a Record<N>
-    pub fn json_bed3_to_noodles_bed3(input: &str) -> String {
-        let record: Record<3> = serde_json::from_str(input).unwrap();
-
-        // TODO: start treating errors
-        noodles_bed::record_to_string(record).unwrap()
-    }
-
-    // test
-    pub fn noodles_bed4_to_json_bed4(input: &str) -> String {
-        let record: Record<4> = noodles_bed::record_from_str(input).unwrap();
-        serde_json::to_string(&record).unwrap()
-    }
-
-    pub fn json_bed4_to_noodles_bed4(input: &str) -> String {
-        let record: Record<4> = serde_json::from_str(input).unwrap();
-        noodles_bed::record_to_string(record).unwrap()
-    }
-
-    #[cfg(test)]
-    mod bioserde_tests {
-        use super::*;
-
-        #[test]
-        fn test_json_bed3_to_noodles_bed3() {
-            let input = r#"{"chrom":"sq0","start":8,"end":13}"#;
-            let result = json_bed3_to_noodles_bed3(input);
-
-            let expected = "sq0\t7\t13";
-            assert_eq!(&result, expected);
-        }
-
-        #[test]
-        fn test_noodles_bed3_to_json_bed3() {
-            let input = "sq0\t7\t13";
-            let result = noodles_bed3_to_json_bed3(input);
-
-            let expected = r#"{"chrom":"sq0","start":8,"end":13,"name":null,"score":null,"strand":null,"thick_start":8,"thick_end":13,"color":null,"blocks":[]}"#;
-            assert_eq!(&result, expected);
-        }
-
-        #[test]
-        fn test_json_bed3_to_noodles_bed3_with_enum_usage() {
-            let input = r#"{"chrom":"sq0","start":8,"end":13}"#;
-            let result =
-                convert_to_format(input, SupportedFormat::JsonBed3, SupportedFormat::Record3);
-
-            let expected = "sq0\t7\t13";
-            assert_eq!(&result, expected);
-        }
-
-        #[test]
-        fn test_noodles_bed3_to_json_bed3_with_enum_usage() {
-            let input = "sq0\t7\t13";
-            let result =
-                convert_to_format(input, SupportedFormat::Record3, SupportedFormat::JsonBed3);
-
-            let expected = r#"{"chrom":"sq0","start":8,"end":13,"name":null,"score":null,"strand":null,"thick_start":8,"thick_end":13,"color":null,"blocks":[]}"#;
-            assert_eq!(&result, expected);
-        }
-
-        #[test]
-        fn test_json_bed4_to_noodles_bed4_with_enum_usage() {
-            let input = r#"{"chrom":"sq0","start":8,"end":13,"name":"ndls1"}"#;
-            let result =
-                convert_to_format(input, SupportedFormat::JsonBed4, SupportedFormat::Record4);
-
-            let expected = "sq0\t7\t13\tndls1";
-            assert_eq!(&result, expected);
-        }
-
-        #[test]
-        fn test_noodles_bed4_to_json_bed4_with_enum_usage() {
-            let input = "sq0\t7\t13\tndls1";
-            let result =
-                convert_to_format(input, SupportedFormat::Record4, SupportedFormat::JsonBed4);
-
-            let expected = r#"{"chrom":"sq0","start":8,"end":13,"name":"ndls1","score":null,"strand":null,"thick_start":8,"thick_end":13,"color":null,"blocks":[]}"#;
-            assert_eq!(&result, expected);
-        }
-    }
-}
 
 /// Demonstration of deserialization.
 fn main() {
@@ -165,16 +13,10 @@ fn main() {
     let records: Vec<Record<3>> = serde_json::from_str(inputs).unwrap();
     println!("\n Testing Vec of json: \n{:#?}", records);
 
-    // For the BED file format representation of a bed::Record, we need to implement our own Deserializer.
-    let record = "sq0\t7\t13";
+    // // For the BED file format representation of a bed::Record, we need to implement our own Deserializer.
+    // let record = "sq0\t7\t13\nsq0\t20\t34\n";
     // let record: Record<3> = noodles_bed::record_from_str(record).unwrap();
-    let record: Record<3> = noodles_bed::record_from_str(record).unwrap();
-    println!("{:#?}", record);
-
-    // For the BED file format representation of a bed::Record, we need to implement our own Deserializer.
-    let record = "sq0\t7\t13\nsq0\t20\t34\n";
-    let vec_record: Vec<Record<3>> = noodles_bed::vec_record_from_str(record).unwrap();
-    println!("{:#?}", vec_record);
+    // println!("{:#?}", record);
 
     // Serialization is similar, if we want the JSON representation, we can use the serde_json Serializer.
     let record = Record::<3>::builder()
@@ -195,12 +37,12 @@ fn main() {
 
     println!("{:#?}", noodles_bed::record_to_string(record).unwrap());
 
-    // // Failing serde-transcode example:
-    // // From json representation to noodles-bed representation
-    // let input = r#"{"chrom":"sq0","start":8,"end":13}"#;
-    // let mut deserializer = serde_json::Deserializer::from_str(input);
-    // let mut serializer = noodles_bed::RecordSerializer::new();
-    // serde_transcode::transcode(&mut deserializer, &mut serializer).unwrap();
+    // Failing serde-transcode example:
+    // From json representation to noodles-bed representation
+    let input = r#"{"chrom":"sq0","start":8,"end":13}"#;
+    let mut deserializer = serde_json::Deserializer::from_str(input);
+    let mut serializer = noodles_bed::RecordSerializer::new();
+    serde_transcode::transcode(&mut deserializer, &mut serializer).unwrap();
 
     // // Failing serde-transcode example:
     // // From json representation to noodles-bed representation
@@ -209,35 +51,5 @@ fn main() {
     // let mut serializer = serde_json::Serializer::new(std::io::stdout());
     // serde_transcode::transcode(&mut deserializer, &mut serializer).unwrap();
 
-    // From noodles-bed representation to json-bed representation
-    let input = r#"{"chrom":"sq0","start":8,"end":13}"#;
-    let result = json_bed3_to_noodles_bed3(input);
-    println!(
-        "json_bed3_to_noodles_bed3: input: {:?}, result: {:?}",
-        input, result
-    );
-
-    // From json-bed representation to noodles-bed representation
-    let input = "sq0\t7\t13";
-    let result = noodles_bed3_to_json_bed3(input);
-    println!(
-        "noodles_bed3_to_json_bed3: input: {:?}, result: {:?}",
-        input, result
-    );
-
-    let input = r#"{"chrom":"sq0","start":8,"end":13}"#;
-    let result = convert_to_format(input, SupportedFormat::JsonBed3, SupportedFormat::Record3);
-
-    println!(
-        "convert_to_format: input: {:?}, result: {:?}",
-        input, result
-    );
-
-    let input = "sq0\t7\t13";
-    let result = convert_to_format(input, SupportedFormat::Record3, SupportedFormat::JsonBed3);
-
-    println!(
-        "convert_to_format: input: {:?}, result: {:?}",
-        input, result
-    );
+    // From noodles-bed representation to json representation
 }

--- a/noodles-bed/src/ser.rs
+++ b/noodles-bed/src/ser.rs
@@ -9,13 +9,20 @@ pub struct RecordSerializer {
     output: String,
 }
 
+impl RecordSerializer {
+    pub fn new() -> Self {
+        RecordSerializer {
+            output: String::new(),
+        }
+    }
+}
+
 fn to_string<T>(value: &T) -> Result<String>
 where
     T: Serialize,
 {
-    let mut serializer = RecordSerializer {
-        output: String::new(),
-    };
+    let mut serializer = RecordSerializer::new();
+
     value.serialize(&mut serializer)?;
     Ok(serializer.output)
 }

--- a/noodles-bed/src/ser.rs
+++ b/noodles-bed/src/ser.rs
@@ -27,27 +27,27 @@ where
     Ok(serializer.output)
 }
 
-pub fn vec_record_to_string<T>(vec: Vec<T>) -> Result<String>
-where
-    T: BedN<3> + std::str::FromStr + std::fmt::Display,
-    <T as std::str::FromStr>::Err: std::fmt::Display,
-{
-    let input: Vec<SerdeRecordWrapper<T>> = vec
-        .into_iter()
-        .map(|record| SerdeRecordWrapper(record))
-        .collect();
+// pub fn vec_record_to_string<T>(vec: Vec<T>) -> Result<String>
+// where
+//     T: BedN<3> + std::str::FromStr + std::fmt::Display,
+//     <T as std::str::FromStr>::Err: std::fmt::Display,
+// {
+//     let input: Vec<SerdeRecordWrapper<T>> = vec
+//         .into_iter()
+//         .map(|record| SerdeRecordWrapper(record))
+//         .collect();
 
-    to_string(&input)
-}
+//     to_string(&input)
+// }
 
-pub fn record_to_string<T>(record: T) -> Result<String>
-where
-    T: BedN<3> + std::str::FromStr + std::fmt::Display,
-    <T as std::str::FromStr>::Err: std::fmt::Display,
-{
-    let srw = SerdeRecordWrapper(record);
-    to_string(&srw)
-}
+// pub fn record_to_string<T>(record: T) -> Result<String>
+// where
+//     T: BedN<3> + std::str::FromStr + std::fmt::Display,
+//     <T as std::str::FromStr>::Err: std::fmt::Display,
+// {
+//     let srw = SerdeRecordWrapper(record);
+//     to_string(&srw)
+// }
 
 pub fn to_bytes<T>(value: &T) -> Result<Vec<u8>>
 where
@@ -68,53 +68,57 @@ impl<'a> ser::Serializer for &'a mut RecordSerializer {
     type SerializeStruct = Self;
     type SerializeStructVariant = Self;
 
-    fn serialize_bool(self, _v: bool) -> Result<()> {
-        unimplemented!()
+    fn serialize_bool(self, v: bool) -> Result<()> {
+        self.output += if v { "true" } else { "false" };
+        Ok(())
     }
 
-    fn serialize_i8(self, _v: i8) -> Result<()> {
-        unimplemented!()
+    fn serialize_i8(self, v: i8) -> Result<()> {
+        self.serialize_i64(i64::from(v))
     }
 
-    fn serialize_i16(self, _v: i16) -> Result<()> {
-        unimplemented!()
+    fn serialize_i16(self, v: i16) -> Result<()> {
+        self.serialize_i64(i64::from(v))
     }
 
-    fn serialize_i32(self, _v: i32) -> Result<()> {
-        unimplemented!()
+    fn serialize_i32(self, v: i32) -> Result<()> {
+        self.serialize_i64(i64::from(v))
     }
 
     // TODO: maybe use the `itoa` crate for performance.
-    fn serialize_i64(self, _v: i64) -> Result<()> {
-        unimplemented!()
+    fn serialize_i64(self, v: i64) -> Result<()> {
+        self.output += &v.to_string();
+        Ok(())
     }
 
-    fn serialize_u8(self, _v: u8) -> Result<()> {
-        unimplemented!()
+    fn serialize_u8(self, v: u8) -> Result<()> {
+        self.serialize_u64(u64::from(v))
     }
 
-    fn serialize_u16(self, _v: u16) -> Result<()> {
-        unimplemented!()
+    fn serialize_u16(self, v: u16) -> Result<()> {
+        self.serialize_u64(u64::from(v))
     }
 
-    fn serialize_u32(self, _v: u32) -> Result<()> {
-        unimplemented!()
+    fn serialize_u32(self, v: u32) -> Result<()> {
+        self.serialize_u64(u64::from(v))
     }
 
-    fn serialize_u64(self, _v: u64) -> Result<()> {
-        unimplemented!()
+    fn serialize_u64(self, v: u64) -> Result<()> {
+        self.output += &v.to_string();
+        Ok(())
     }
 
-    fn serialize_f32(self, _v: f32) -> Result<()> {
-        unimplemented!()
+    fn serialize_f32(self, v: f32) -> Result<()> {
+        self.serialize_f64(f64::from(v))
     }
 
-    fn serialize_f64(self, _v: f64) -> Result<()> {
-        unimplemented!()
+    fn serialize_f64(self, v: f64) -> Result<()> {
+        self.output += &v.to_string();
+        Ok(())
     }
 
-    fn serialize_char(self, _v: char) -> Result<()> {
-        unimplemented!()
+    fn serialize_char(self, v: char) -> Result<()> {
+        self.serialize_str(v.encode_utf8(&mut [0; 4]))
     }
 
     fn serialize_str(self, v: &str) -> Result<()> {
@@ -123,35 +127,38 @@ impl<'a> ser::Serializer for &'a mut RecordSerializer {
     }
 
     fn serialize_bytes(self, _v: &[u8]) -> Result<()> {
-        unimplemented!()
+        unimplemented!();
     }
 
     fn serialize_none(self) -> Result<()> {
-        unimplemented!()
+        self.serialize_unit()
     }
 
-    fn serialize_some<T>(self, _value: &T) -> Result<()>
+    fn serialize_some<T>(self, value: &T) -> Result<()>
     where
         T: ?Sized + Serialize,
     {
-        unimplemented!()
+        value.serialize(self)
     }
 
+    // TODO: check all unorthodox serialization decisions
+    //     (maybe unexpected data serializations should return an error)
     fn serialize_unit(self) -> Result<()> {
-        unimplemented!()
+        self.output += "null";
+        Ok(())
     }
 
     fn serialize_unit_struct(self, _name: &'static str) -> Result<()> {
-        unimplemented!()
+        self.serialize_unit()
     }
 
     fn serialize_unit_variant(
         self,
         _name: &'static str,
         _variant_index: u32,
-        _variant: &'static str,
+        variant: &'static str,
     ) -> Result<()> {
-        unimplemented!()
+        self.serialize_str(variant)
     }
 
     fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<()>
@@ -166,56 +173,63 @@ impl<'a> ser::Serializer for &'a mut RecordSerializer {
         _name: &'static str,
         _variant_index: u32,
         _variant: &'static str,
-        _value: &T,
+        value: &T,
     ) -> Result<()>
     where
         T: ?Sized + Serialize,
     {
-        unimplemented!()
+        value.serialize(self)
     }
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq> {
         Ok(self)
     }
 
+    // TODO: `blocks` field uses this, make a test with it
     fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple> {
-        unimplemented!()
+        Ok(self)
     }
 
     fn serialize_tuple_struct(
         self,
         _name: &'static str,
-        _len: usize,
+        len: usize,
     ) -> Result<Self::SerializeTupleStruct> {
-        unimplemented!()
+        self.serialize_seq(Some(len))
     }
 
     fn serialize_tuple_variant(
         self,
         _name: &'static str,
         _variant_index: u32,
-        _variant: &'static str,
+        variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant> {
-        unimplemented!()
+        self.output += "{";
+        variant.serialize(&mut *self)?;
+        self.output += ":[";
+        Ok(self)
     }
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
-        unimplemented!()
+        Ok(self)
     }
 
     fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
-        unimplemented!()
+        Ok(self)
     }
 
     fn serialize_struct_variant(
         self,
         _name: &'static str,
         _variant_index: u32,
-        _variant: &'static str,
+        variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant> {
-        unimplemented!()
+        self.output += "{";
+        variant.serialize(&mut *self)?;
+        self.output += ":{";
+        Ok(self)
     }
 }
 
@@ -227,9 +241,7 @@ impl<'a> ser::SerializeSeq for &'a mut RecordSerializer {
     where
         T: ?Sized + Serialize,
     {
-        value.serialize(&mut **self)?;
-        self.output += "\n";
-        Ok(())
+        value.serialize(&mut **self)
     }
 
     fn end(self) -> Result<()> {
@@ -241,15 +253,19 @@ impl<'a> ser::SerializeTuple for &'a mut RecordSerializer {
     type Ok = ();
     type Error = Error;
 
-    fn serialize_element<T>(&mut self, _value: &T) -> Result<()>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
     where
         T: ?Sized + Serialize,
     {
-        unimplemented!()
+        if !self.output.ends_with('(') {
+            self.output += ",";
+        }
+        value.serialize(&mut **self)
     }
 
     fn end(self) -> Result<()> {
-        unimplemented!()
+        self.output += ")";
+        Ok(())
     }
 }
 
@@ -257,15 +273,15 @@ impl<'a> ser::SerializeTupleStruct for &'a mut RecordSerializer {
     type Ok = ();
     type Error = Error;
 
-    fn serialize_field<T>(&mut self, _value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
     where
         T: ?Sized + Serialize,
     {
-        unimplemented!()
+        value.serialize(&mut **self)
     }
 
     fn end(self) -> Result<()> {
-        unimplemented!()
+        Ok(())
     }
 }
 
@@ -273,15 +289,15 @@ impl<'a> ser::SerializeTupleVariant for &'a mut RecordSerializer {
     type Ok = ();
     type Error = Error;
 
-    fn serialize_field<T>(&mut self, _value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
     where
         T: ?Sized + Serialize,
     {
-        unimplemented!()
+        value.serialize(&mut **self)
     }
 
     fn end(self) -> Result<()> {
-        unimplemented!()
+        Ok(())
     }
 }
 
@@ -293,18 +309,22 @@ impl<'a> ser::SerializeMap for &'a mut RecordSerializer {
     where
         T: ?Sized + Serialize,
     {
-        unimplemented!()
+        if !self.output.is_empty() && !self.output.ends_with('\n') {
+            self.output += "\t";
+        }
+        Ok(())
     }
 
-    fn serialize_value<T>(&mut self, _value: &T) -> Result<()>
+    fn serialize_value<T>(&mut self, value: &T) -> Result<()>
     where
         T: ?Sized + Serialize,
     {
-        unimplemented!()
+        value.serialize(&mut **self)
     }
 
     fn end(self) -> Result<()> {
-        unimplemented!()
+        self.output += "\n";
+        Ok(())
     }
 }
 
@@ -312,15 +332,19 @@ impl<'a> ser::SerializeStruct for &'a mut RecordSerializer {
     type Ok = ();
     type Error = Error;
 
-    fn serialize_field<T>(&mut self, _key: &'static str, _value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<()>
     where
         T: ?Sized + Serialize,
     {
-        unimplemented!()
+        if !self.output.is_empty() && !self.output.ends_with('\n') {
+            self.output += "\t";
+        }
+        value.serialize(&mut **self)
     }
 
     fn end(self) -> Result<()> {
-        unimplemented!()
+        self.output += "\t";
+        Ok(())
     }
 }
 
@@ -328,15 +352,19 @@ impl<'a> ser::SerializeStructVariant for &'a mut RecordSerializer {
     type Ok = ();
     type Error = Error;
 
-    fn serialize_field<T>(&mut self, _key: &'static str, _value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<()>
     where
         T: ?Sized + Serialize,
     {
-        unimplemented!()
+        if !self.output.is_empty() && !self.output.ends_with('\n') {
+            self.output += "\t";
+        }
+        value.serialize(&mut **self)
     }
 
     fn end(self) -> Result<()> {
-        unimplemented!()
+        self.output += "\t";
+        Ok(())
     }
 }
 
@@ -358,14 +386,14 @@ mod serde_tests {
             .build()
             .unwrap();
 
-        let result = record_to_string(record).unwrap();
+        let result = to_string(&record).unwrap();
         let expected = "sq0\t7\t13";
 
         assert_eq!(&result, expected);
     }
 
     #[test]
-    fn test_to_string_multiple_auxiliar_bed_record_wrapper() {
+    fn test_to_string_multiple_auxiliar_bed_record_3_wrapper() {
         let record1 = Record::<3>::builder()
             .set_reference_sequence_name("sq0")
             .set_start_position(noodles_core::Position::try_from(8).unwrap())
@@ -382,7 +410,7 @@ mod serde_tests {
 
         let input = vec![record1, record2];
 
-        let result = vec_record_to_string(input).unwrap();
+        let result = to_string(&input).unwrap();
         let expected = "sq0\t7\t13\nsq1\t13\t18\n";
         assert_eq!(&result, expected);
     }
@@ -397,7 +425,7 @@ mod serde_tests {
             .build()
             .unwrap();
 
-        let result = record_to_string(record).unwrap();
+        let result = to_string(&record).unwrap();
         let expected = "sq0\t7\t13\tndls1";
 
         assert_eq!(&result, expected);
@@ -413,7 +441,7 @@ mod serde_tests {
             .build()
             .unwrap();
 
-        let result = record_to_string(record).unwrap();
+        let result = to_string(&record).unwrap();
         let expected = "sq0\t7\t13\t.\t21";
 
         assert_eq!(&result, expected);
@@ -429,7 +457,7 @@ mod serde_tests {
             .build()
             .unwrap();
 
-        let result = record_to_string(record).unwrap();
+        let result = to_string(&record).unwrap();
         let expected = "sq0\t7\t13\t.\t0\t+";
 
         assert_eq!(&result, expected);
@@ -447,7 +475,7 @@ mod serde_tests {
             .build()
             .unwrap();
 
-        let result = record_to_string(record).unwrap();
+        let result = to_string(&record).unwrap();
         let expected = "sq0\t7\t13\t.\t0\t.\t7";
 
         assert_eq!(&result, expected);
@@ -467,7 +495,7 @@ mod serde_tests {
             .build()
             .unwrap();
 
-        let result = record_to_string(record).unwrap();
+        let result = to_string(&record).unwrap();
         let expected = "sq0\t7\t13\t.\t0\t.\t7\t13";
 
         assert_eq!(&result, expected);
@@ -488,7 +516,7 @@ mod serde_tests {
             .build()
             .unwrap();
 
-        let result = record_to_string(record).unwrap();
+        let result = to_string(&record).unwrap();
         let expected = "sq0\t7\t13\t.\t0\t.\t7\t13\t255,0,0";
 
         assert_eq!(&result, expected);
@@ -509,7 +537,7 @@ mod serde_tests {
             .build()
             .unwrap();
 
-        let result = record_to_string(record).unwrap();
+        let result = to_string(&record).unwrap();
         let expected = "sq0\t7\t13\t.\t0\t.\t7\t13\t0\t1\t2\t0";
 
         assert_eq!(&result, expected);


### PR DESCRIPTION
1) Using `serde-transcode` in order to convert one format into the other:

The first commit of this PR focuses on trying to use `serde-transcode` as the solution to `BioSerDe` proposal. This however does not currently work, because we cannot give the serde mechanism a hint in which type we are expecting:

```rust
// Failing serde-transcode example:
// From json representation to noodles-bed representation
let input = r#"{"chrom":"sq0","start":8,"end":13}"#;
let mut deserializer = serde_json::Deserializer::from_str(input);
let mut serializer = noodles_bed::RecordSerializer::new();
serde_transcode::transcode(&mut deserializer, &mut serializer).unwrap();
```

Notice that the only information inside this is the Serializer and Deserializer of the target formats, whereas our currently code only works when we explicitly use the `SerdeRecordWrapper` via our auxiliar functions.

One problem with not using transcode would be the use of intermediary memory, aswell as a reduction in the simplicity of the code:

`The [serde-transcode](https://github.com/sfackler/serde-transcode) crate provides functionality to "transcode" from an arbitrary Serde Deserializer to an arbitrary Serde Serializer without needing to collect the entire input into an intermediate form in memory.`

But it seems to me that in order to use transcode, we cannot give the serde mechanism a hint in which type we are expecting, if we do that, we will need to go back in our decision of using `serde-with` in order to use the `FromStr` and `Display` already implemented in the noodles crate to accelerate the experiment.

Another problem with **using** transcode, is that we need to have access to the `Serializer` and `Deserializer` of the format we are dealing with, however, some crates may choose to keep those objects private. That seems to be the case for the `rust-csv` crate for example, if I didn't mess up my demo earlier, it could be that the only formats that make this choice will not be the ones where it makes sense to use in bioserde, especially since WE are the ones implementing serde for at least the noodles formats, so they would always be public for our own sake hehe.

2) Trying a manual approach

In order to weight if we really have to eat this bullet, I've tried to explore how would we do this functionality manually on the subsequential commits of this branch, currently it isn't going great:

First I've tried to create single functions for each format:

```rust
    pub fn noodles_bed_to_json_bed(input: &str) -> String {
        let record: Record<3> = noodles_bed::record_from_str(input).unwrap();

        // TODO: start treating errors
        serde_json::to_string(&record).unwrap()
    }
```

That doesn't sound like it's correct, since we would need one function for each Record<N>.

Then I've tried to make a more generic function with an enum of `SupportedFormats`, which initially, could not generalize, since it would expect many Record<N> types in the same function, which rust does not allow

```rust
    pub fn convert_to_format(input: &str, from: SupportedFormat, to: SupportedFormat) -> String {
        let record = match from {
            SupportedFormat::Record3 => noodles_bed::record_from_str::<Record<3>>(input).unwrap(),
            SupportedFormat::Record4 => noodles_bed::record_from_str::<Record<4>>(input).unwrap(),
            SupportedFormat::JsonBed3 => serde_json::from_str::<Record<3>>(input).unwrap(),
            SupportedFormat::JsonBed4 => serde_json::from_str::<Record<4>>(input).unwrap(),
        };

        match to {
            SupportedFormat::Record3 | SupportedFormat::Record4 => {
                noodles_bed::record_to_string(record).unwrap()
            }
            SupportedFormat::JsonBed3 | SupportedFormat::JsonBed4 => {
                serde_json::to_string(&record).unwrap()
            }
        }
    }
```

```
error[E0308]: `match` arms have incompatible types
  --> noodles-bed/src/main.rs:46:41
   |
44 |           let record = match from {
   |  ______________________-
45 | |             SupportedFormat::Record3 => noodles_bed::record_from_str::<Record<3>>(input).unwrap(),
   | |                                         --------------------------------------------------------- this is found to be of type `Record<3_u8>`
46 | |             SupportedFormat::Record4 => noodles_bed::record_from_str::<Record<4>>(input).unwrap(),
   | |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `3_u8`, found `4_u8`
47 | |             SupportedFormat::JsonBed3 => serde_json::from_str::<Record<3>>(input).unwrap(),
48 | |             SupportedFormat::JsonBed4 => serde_json::from_str::<Record<4>>(input).unwrap(),
49 | |         };
   | |_________- `match` arms have incompatible types
   |
   = note: expected struct `Record<3_u8>`
              found struct `Record<4_u8>`
```

Then, I've realized that we can merge the 2 approaches to have a function that does the whole serde process for each input, which works. (I will not print it here, since it's the current version) 

However it's really verbose, we need both a) better ways to fill the match patterns in a way that allows only valid conversions, and b) probably, use macros to create all the functions needed, (which raises exponentially with each added format), that however, sound like it could work well.

My current plan is to persue these enhancements and see if the code is good enough, if however you guys have questions or other ideas, please let me know (:

p.s.: the current code is kinda ugly and have some things I still have to check (such as, if a JsonBed3 and JsonBed4 are really needed), but I still wanted to submit the architecture idea.
